### PR TITLE
keylime_agent.service: use KillSignal=SIGINT

### DIFF
--- a/debian/python3-keylime-agent.keylime_agent.service
+++ b/debian/python3-keylime-agent.keylime_agent.service
@@ -14,6 +14,7 @@ Environment=TPM2TOOLS_TCTI=device:/dev/tpmrm0 KEYLIME_CONFIG=/etc/keylime-agent.
 ExecStartPre=-+chown -hHR keylime:tss /sys/kernel/security/tpm0
 ExecStartPre=-+chown -hHR keylime:tss /sys/kernel/security/ima
 ExecStart=/usr/bin/keylime_agent
+KillSignal=SIGINT
 TimeoutSec=60s
 Restart=on-failure
 RestartSec=120s


### PR DESCRIPTION
If systemd sends SIGTERM to the agent it terminates the agent immediately
without the cleanup functions being called. This will result in the TPM NV
being full after a couple of agent restarts.

Using SIGINT instead of SIGTERM fixes this issue.