### PR TITLE
A separate package for tenant tool

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -30,14 +30,16 @@ Architecture: all
 Depends: python3-keylime-server,
          python3-keylime-agent,
          python3-keylime-agent-local,
+         python3-keylime-tenant,
          ${misc:Depends}
 Description: Keylime - full local install
  ${Description}
  .
- This is a metapackage meant for compatibility with former versions and will
- depend on python3-keylime-server and python3-keylime-agent as well as
- python3-keylime-agent-local bringing all services onto the local system
- including a configuration to connect against the local services.
+ This is a metapackage meant for compatibility with former versions
+ and will depend on python3-keylime-tenant, python3-keylime-server and
+ python3-keylime-agent as well as python3-keylime-agent-local bringing
+ all services onto the local system including a configuration to connect
+ against the local services.
 
 Package: python3-keylime-lib
 Architecture: all
@@ -70,6 +72,7 @@ Depends: adduser,
          python3,
          ${misc:Depends},
          ${python3:Depends}
+Recommends: python3-keylime-tenant
 Description: Keylime registrar and verifier
  ${Description}
  .
@@ -93,6 +96,18 @@ Description: Keylime agent
  Once you deploy /etc/keylime-agent.conf via any means the service will
  start using that configuration. There is an /etc/keylime-agent.conf.example
  provided to start with.
+
+Package: python3-keylime-tenant
+Architecture: all
+Depends: adduser,
+         python3-keylime-lib,
+         python3,
+         ${misc:Depends},
+         ${python3:Depends}
+Description: Keylime tenant tool
+ ${Description}
+ .
+ A tool for provisioning and to control keylime suite.
 
 Package: python3-keylime-agent-local
 Architecture: all

--- a/debian/python3-keylime-agent.install
+++ b/debian/python3-keylime-agent.install
@@ -1,5 +1,1 @@
-#!/usr/bin/dh-exec
 usr/bin/keylime_agent usr/bin/
-
-
-etc/keylime.conf => /etc/keylime-agent.conf.example

--- a/debian/python3-keylime-server.install
+++ b/debian/python3-keylime-server.install
@@ -6,7 +6,6 @@ usr/bin/keylime_provider_platform_init
 usr/bin/keylime_provider_registrar
 usr/bin/keylime_provider_vtpm_add
 usr/bin/keylime_registrar
-usr/bin/keylime_tenant
 usr/bin/keylime_userdata_encrypt
 usr/bin/keylime_webapp
 

--- a/debian/python3-keylime-server.install
+++ b/debian/python3-keylime-server.install
@@ -10,4 +10,3 @@ usr/bin/keylime_userdata_encrypt
 usr/bin/keylime_webapp
 
 tpm_cert_store var/lib/keylime
-etc/keylime.conf

--- a/debian/python3-keylime-tenant.install
+++ b/debian/python3-keylime-tenant.install
@@ -1,0 +1,2 @@
+#!/usr/bin/dh-exec
+usr/bin/keylime_tenant

--- a/debian/python3-keylime-tenant.install
+++ b/debian/python3-keylime-tenant.install
@@ -1,2 +1,1 @@
-#!/usr/bin/dh-exec
 usr/bin/keylime_tenant

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,11 @@ export KEYLIME_CONFIG=$(CURDIR)/keylime.conf
 	dh $@ --with python3 --buildsystem=pybuild
 
 override_dh_install:
+	# The same file goes into multiple places
+	install -D -m 0644 keylime.conf debian/python3-keylime-server/etc/keylime.conf
 	install -D -m 0644 keylime.conf debian/python3-keylime-agent-local/etc/keylime-agent.conf
+	install -D -m 0644 keylime.conf debian/python3-keylime-agent/etc/keylime-agent.conf.example
+	install -D -m 0644 keylime.conf debian/python3-keylime-tenant/etc/keylime-tenant.conf
 	dh_install
 
 override_dh_installdeb:


### PR DESCRIPTION
Hi team,

Here you have in a separate package the keylime_tenant tool. @cpaelzer helped with the conf file and adapted the deployment of all config files in the same way as well.

Checked the installation and availability of the new package and tool:

```
root@bionic-keylime-split:~/Code/src# dpkg -i python3-keylime-tenant_6.1.1-1~ibmcloud0.1_all.deb
Selecting previously unselected package python3-keylime-tenant.
(Reading database ... 107908 files and directories currently installed.)
Preparing to unpack python3-keylime-tenant_6.1.1-1~ibmcloud0.1_all.deb ...
Unpacking python3-keylime-tenant (6.1.1-1~ibmcloud0.1) ...
Setting up python3-keylime-tenant (6.1.1-1~ibmcloud0.1) ...
root@bionic-keylime-split:~/Code/src# key
keylime_tenant  keyring  
```

Thanks in advance... anything that needs to be changed, feel free to comment!