### PR TITLE
Simulating use of SSLContext.minimum_version w/ Python 3.6

### DIFF
--- a/debian/patches/series
+++ b/debian/patches/series
@@ -1,1 +1,2 @@
 embed-dataclasses-module.patch
+using-ssl3.6-constant-for-TLSv12.patch

--- a/debian/patches/using-ssl3.6-constant-for-TLSv12.patch
+++ b/debian/patches/using-ssl3.6-constant-for-TLSv12.patch
@@ -1,0 +1,39 @@
+Description: This patch simulates behaviour of ussing ssl
+ v3.7 with its equivalent in v3.6, for avoid this error
+ on Ubuntu Bionic (18.04):
+ ```
+ AttributeError: module 'ssl' has no attribute 'TLSVersion'
+ ```
+ and
+ ```
+ AttributeError: 'SSLContext' object has no attribute 'minimum_version'
+ ```
+Author: Miriam España Acebal <miriam.espana@canonical.com>
+Origin: vendor
+Forwarded: https://github.com/keylime/keylime/pull/752
+Last-Update: 2021-09-13
+
+Index: python-keylime/keylime/cloud_verifier_common.py
+===================================================================
+--- a/keylime/cloud_verifier_common.py	2021-09-13 10:43:49.790895288 +0200
++++ b/keylime/cloud_verifier_common.py	2021-09-13 11:01:55.819610186 +0200
+@@ -9,6 +9,7 @@
+ import ssl
+ import socket
+ import time
++import sys
+
+ import simplejson as json
+
+@@ -114,7 +115,10 @@
+
+     try:
+         context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+-        context.minimum_version = ssl.TLSVersion.TLSv1_2
++        if sys.version_info >= (3,7):
++            context.minimum_version = ssl.TLSVersion.TLSv1_2
++        else:
++            context.options &= ~ssl.OP_NO_TLSv1_2
+         context.load_verify_locations(cafile=ca_path)
+         context.load_cert_chain(
+             certfile=my_cert, keyfile=my_priv_key, password=my_key_pw)


### PR DESCRIPTION
As commented in #23, keylime code is using SSL library version 3.7+ but we have 3.6 in Focal.   So, the idea is to adapt the needed calls or use of functions and constant to 3.6 with the same functionality. Following this https://docs.python.org/3/library/ssl.html#ssl.OP_NO_TLSv1, here is a patch proposal.

Tested that services start ok (you can see it also in #23).

Thanks!

P.S.: Changelog hasn't been touched waiting for this to be ok or not. 