### PR TITLE
Don't auto-start services on installation or upgrades

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,9 +21,9 @@ override_dh_installdeb:
 	dh_installdeb
 
 override_dh_installsystemd:
-	dh_installsystemd -p python3-keylime-agent --name keylime_agent
-	dh_installsystemd -p python3-keylime-server --name keylime_registrar
-	dh_installsystemd -p python3-keylime-server --name keylime_verifier
+	dh_installsystemd -p python3-keylime-agent --no-start --name keylime_agent
+	dh_installsystemd -p python3-keylime-server --no-start --name keylime_registrar
+	dh_installsystemd -p python3-keylime-server --no-start --name keylime_verifier
 	dh_installsystemd -p python3-keylime-agent --name var-lib-keylime-secure
 
 override_dh_gencontrol:


### PR DESCRIPTION
The default configuration for keylime agent specifies a
default TPM password (“keylime”). If the agent initializes
the TPM device with the above password, it later becomes
very difficult to change this.

Starting the keylime agent atop the default configuration
(python3-keylime-defaultconfig) is unlikely to be successful
anyway, since the default configuration assumes a co-located
keylime verifier/registrar; very unlikely in a production
setting.

Closes: #29