### PR TITLE
Drop libtss2-dev from Depends/Build-Depends

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,6 @@ Priority: optional
 Build-Depends: debhelper (>= 11),
                dh-exec,
                dh-python,
-               libtss2-dev,
                python3-alembic,
                python3-all,
                python3-cryptography,
@@ -44,8 +43,7 @@ Description: Keylime - full local install
 
 Package: python3-keylime-lib
 Architecture: all
-Depends: libtss2-dev,
-         python3,
+Depends: python3,
          python3-cryptography,
          python3-gnupg,
          python3-m2crypto,


### PR DESCRIPTION
Apparently, libtss2-dev isn't really needed by keylime
and I am not sure why it was added in the first place.
Anyway, removing it for now. We can always rever later
when we have a reason to add this. \o/

Closes: #34