### PR TITLE
d/{rules, defaultconf.postinst}: adjust permissions of keylime.conf

### DIFF
--- a/debian/common.postinst.in
+++ b/debian/common.postinst.in
@@ -1,9 +1,7 @@
-#!/bin/sh
+# shared functions between all postinst files
 
-set -e
-
-case "$1" in
-    configure)
+keylime_setup_group_user ()
+{
     # creating tss group if he isn't already there
     if ! getent group tss >/dev/null; then
         addgroup --system tss
@@ -24,22 +22,4 @@ case "$1" in
                 --gecos "Keylime remote attestation" \
                 keylime
     fi
-
-    # Setting owner and file permissions
-    if [ -f /etc/keylime.conf ] && ! dpkg-statoverride --list /etc/keylime.conf >/dev/null && getent passwd keylime >/dev/null; then
-        chown -R keylime:tss /etc/keylime.conf
-        chmod 600 /etc/keylime.conf
-    fi
-
-    ;;
-
-    abort-upgrade|abort-remove|abort-deconfigure)
-    ;;
-
-    *)
-        echo "postinst called with unknown argument \`$1'" >&2
-        exit 1
-    ;;
-esac
-
-#DEBHELPER#
+}

--- a/debian/python3-keylime-defaultconf.postinst
+++ b/debian/python3-keylime-defaultconf.postinst
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+set -e
+
+case "$1" in
+    configure)
+    # creating tss group if he isn't already there
+    if ! getent group tss >/dev/null; then
+        addgroup --system tss
+    fi
+
+    # creating tss user if he isn't already there
+    if ! getent passwd tss >/dev/null; then
+        adduser --system --ingroup tss --shell /bin/false \
+                --home /var/lib/tpm --no-create-home \
+                --gecos "TPM software stack" \
+                tss
+    fi
+
+    # creating keylime user if he isn't already there
+    if ! getent passwd keylime >/dev/null; then
+        adduser --system --ingroup tss --shell /bin/false \
+                --home /var/lib/keylime --no-create-home \
+                --gecos "Keylime remote attestation" \
+                keylime
+    fi
+
+    # Setting owner and file permissions
+    if [ -f /etc/keylime.conf ] && getent passwd keylime >/dev/null; then
+        chown -R keylime:tss /etc/keylime.conf
+        chmod 600 /etc/keylime.conf
+    fi
+
+    ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+#DEBHELPER#

--- a/debian/python3-keylime-defaultconf.postinst
+++ b/debian/python3-keylime-defaultconf.postinst
@@ -26,7 +26,7 @@ case "$1" in
     fi
 
     # Setting owner and file permissions
-    if [ -f /etc/keylime.conf ] && getent passwd keylime >/dev/null; then
+    if [ -f /etc/keylime.conf ] && ! dpkg-statoverride --list /etc/keylime.conf >/dev/null && getent passwd keylime >/dev/null; then
         chown -R keylime:tss /etc/keylime.conf
         chmod 600 /etc/keylime.conf
     fi

--- a/debian/python3-keylime-defaultconf.postinst.in
+++ b/debian/python3-keylime-defaultconf.postinst.in
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+set -e
+
+#KEYLIME_COMMON#
+
+case "$1" in
+    configure)
+    # Setup the keylime user and the tss group
+    keylime_setup_group_user
+
+    # Setting owner and file permissions
+    if [ -f /etc/keylime.conf ] && ! dpkg-statoverride --list /etc/keylime.conf >/dev/null && getent passwd keylime >/dev/null; then
+        chown -R keylime:tss /etc/keylime.conf
+        chmod 600 /etc/keylime.conf
+    fi
+
+    ;;
+
+    abort-upgrade|abort-remove|abort-deconfigure)
+    ;;
+
+    *)
+        echo "postinst called with unknown argument \`$1'" >&2
+        exit 1
+    ;;
+esac
+
+#DEBHELPER#

--- a/debian/python3-keylime.postinst.in
+++ b/debian/python3-keylime.postinst.in
@@ -3,28 +3,12 @@
 set -e
 KEYLIME_PART=@keylime_part@
 
+#KEYLIME_COMMON#
+
 case "$1" in
     configure)
-    # creating tss group if he isn't already there
-    if ! getent group tss >/dev/null; then
-        addgroup --system tss
-    fi
-
-    # creating tss user if he isn't already there
-    if ! getent passwd tss >/dev/null; then
-        adduser --system --ingroup tss --shell /bin/false \
-                --home /var/lib/tpm --no-create-home \
-                --gecos "TPM software stack" \
-                tss
-    fi
-
-    # creating keylime user if he isn't already there
-    if ! getent passwd keylime >/dev/null; then
-        adduser --system --ingroup tss --shell /bin/false \
-                --home /var/lib/keylime --no-create-home \
-                --gecos "Keylime remote attestation" \
-                keylime
-    fi
+    # Setup the keylime user and the tss group
+    keylime_setup_group_user
 
     # Mark what part is installed
     touch "/var/lib/keylime/python3-keylime-${KEYLIME_PART}.installed"

--- a/debian/python3-keylime.postinst.in
+++ b/debian/python3-keylime.postinst.in
@@ -30,12 +30,12 @@ case "$1" in
     touch "/var/lib/keylime/python3-keylime-${KEYLIME_PART}.installed"
 
     # Setting owner
-    if [ -d /var/lib/keylime ] && getent passwd keylime >/dev/null; then
+    if [ -d /var/lib/keylime ] && ! dpkg-statoverride --list /var/lib/keylime >/dev/null && getent passwd keylime >/dev/null; then
         chown -R keylime:tss /var/lib/keylime
     fi
 
     # Setting owner of log dir of server
-    if [ "${KEYLIME_PART}" = "server" ] && [ -d /var/log/keylime ] && getent passwd keylime >/dev/null; then
+    if [ "${KEYLIME_PART}" = "server" ] && [ -d /var/log/keylime ] && ! dpkg-statoverride --list /var/log/keylime >/dev/null && getent passwd keylime >/dev/null; then
         chown keylime:tss /var/log/keylime
     fi
 

--- a/debian/rules
+++ b/debian/rules
@@ -14,8 +14,9 @@ override_dh_install:
 	dh_install
 
 override_dh_installdeb:
-	sed 's/@keylime_part@/server/' debian/python3-keylime.postinst.in > debian/python3-keylime-server.postinst
-	sed 's/@keylime_part@/agent/' debian/python3-keylime.postinst.in > debian/python3-keylime-agent.postinst
+	sed -e 's/@keylime_part@/server/' -e '/#KEYLIME_COMMON#/ r debian/common.postinst.in' debian/python3-keylime.postinst.in > debian/python3-keylime-server.postinst
+	sed -e 's/@keylime_part@/agent/' -e '/#KEYLIME_COMMON#/ r debian/common.postinst.in' debian/python3-keylime.postinst.in > debian/python3-keylime-agent.postinst
+	sed -e '/#KEYLIME_COMMON#/ r debian/common.postinst.in' debian/python3-keylime-defaultconf.postinst.in > debian/python3-keylime-defaultconf.postinst
 	sed 's/@keylime_part@/server/' debian/python3-keylime.postrm.in > debian/python3-keylime-server.postrm
 	sed 's/@keylime_part@/agent/' debian/python3-keylime.postrm.in > debian/python3-keylime-agent.postrm
 	dh_installdeb


### PR DESCRIPTION
The keylime.conf should only be readable by the keylime user.
The keylime.conf might contain passwords that a normal user should not be able to read.

Upstream change: https://github.com/keylime/keylime/pull/844